### PR TITLE
Prevent IndexError if max_count too low

### DIFF
--- a/sre_yield/__init__.py
+++ b/sre_yield/__init__.py
@@ -374,6 +374,7 @@ class RegexMembershipSequence(WrappedSequence):
     def max_repeat_values(self, min_count, max_count, items):
         """Sequential expansion of the count to be combinatorics."""
         max_count = min(max_count, self.max_count)
+        max_count = max(max_count, min_count)
         return RepetitiveSequence(self.sub_values(items), min_count, max_count)
 
     def in_values(self, items):

--- a/sre_yield/tests/test_sre_yield.py
+++ b/sre_yield/tests/test_sre_yield.py
@@ -161,6 +161,14 @@ class YieldTest(unittest.TestCase):
         parsed = sre_yield.AllStrings("[01]+", max_count=4)
         self.assertEqual("1111", parsed[-1])
 
+    def testMinCount(self):
+        parsed = sre_yield.AllStrings(r"\d{0}")
+        self.assertEqual([""], list(parsed))
+        parsed = sre_yield.AllStrings(r"\d{2}")
+        self.assertEqual("99", parsed[-1])
+        parsed = sre_yield.AllStrings(r"\d{2}", max_count=1)
+        self.assertEqual("99", parsed[-1])
+
     def testParseErrors(self):
         self.assertRaises(sre_yield.ParseError, sre_yield.AllStrings, "a", re.I)
         self.assertRaises(sre_yield.ParseError, sre_yield.AllStrings, "a", re.U)


### PR DESCRIPTION
Fixes https://github.com/google/sre_yield/issues/23